### PR TITLE
Add custom external name configurations

### DIFF
--- a/config/external_name.go
+++ b/config/external_name.go
@@ -109,6 +109,11 @@ var privateNetworkIdentifierFromProvider = config.ExternalName{
 	SetIdentifierArgumentFn: config.NopSetIdentifierArgument,
 	GetExternalNameFn:       config.IDAsExternalName,
 	GetIDFn: func(ctx context.Context, externalName string, parameters map[string]any, providerConfig map[string]any) (string, error) {
+		// If external-name is empty, the resource hasn't been created yet,
+		// so we should return empty string instead of constructing an incomplete ID
+		if externalName == "" {
+			return "", nil
+		}
 		serviceName, err := serviceName(parameters)
 		if err != nil {
 			return serviceName, err
@@ -122,6 +127,11 @@ var subnetIdentifierFromProvider = config.ExternalName{
 	SetIdentifierArgumentFn: config.NopSetIdentifierArgument,
 	GetExternalNameFn:       config.IDAsExternalName,
 	GetIDFn: func(ctx context.Context, externalName string, parameters map[string]any, providerConfig map[string]any) (string, error) {
+		// If external-name is empty, the resource hasn't been created yet,
+		// so we should return empty string instead of constructing an incomplete ID
+		if externalName == "" {
+			return "", nil
+		}
 		serviceName, err := serviceName(parameters)
 		if err != nil {
 			return serviceName, err
@@ -145,6 +155,11 @@ var userIdentifierFromProvider = config.ExternalName{
 	SetIdentifierArgumentFn: config.NopSetIdentifierArgument,
 	GetExternalNameFn:       config.IDAsExternalName,
 	GetIDFn: func(ctx context.Context, externalName string, parameters map[string]any, providerConfig map[string]any) (string, error) {
+		// If external-name is empty, the resource hasn't been created yet,
+		// so we should return empty string instead of constructing an incomplete ID
+		if externalName == "" {
+			return "", nil
+		}
 		serviceName, err := serviceName(parameters)
 		if err != nil {
 			return serviceName, err
@@ -158,6 +173,11 @@ var s3CredentialsIdentifierFromProvider = config.ExternalName{
 	SetIdentifierArgumentFn: config.NopSetIdentifierArgument,
 	GetExternalNameFn:       config.IDAsExternalName,
 	GetIDFn: func(ctx context.Context, externalName string, parameters map[string]any, providerConfig map[string]any) (string, error) {
+		// If external-name is empty, the resource hasn't been created yet,
+		// so we should return empty string instead of constructing an incomplete ID
+		if externalName == "" {
+			return "", nil
+		}
 		serviceName, err := serviceName(parameters)
 		if err != nil {
 			return serviceName, err
@@ -181,6 +201,10 @@ var s3PolicyIdentifierFromProvider = config.ExternalName{
 	SetIdentifierArgumentFn: config.NopSetIdentifierArgument,
 	GetExternalNameFn:       config.IDAsExternalName,
 	GetIDFn: func(ctx context.Context, externalName string, parameters map[string]any, providerConfig map[string]any) (string, error) {
+		// S3Policy doesn't use external-name in its ID format, but we still need
+		// to check if required parameters are available. For newly created resources
+		// without an external-name, we should still be able to construct the ID
+		// since it only depends on service_name/user_id.
 		serviceName, err := serviceName(parameters)
 		if err != nil {
 			return serviceName, err
@@ -204,6 +228,11 @@ var gatewayIdentifierFromProvider = config.ExternalName{
 	SetIdentifierArgumentFn: config.NopSetIdentifierArgument,
 	GetExternalNameFn:       config.IDAsExternalName,
 	GetIDFn: func(ctx context.Context, externalName string, parameters map[string]any, providerConfig map[string]any) (string, error) {
+		// If external-name is empty, the resource hasn't been created yet,
+		// so we should return empty string instead of constructing an incomplete ID
+		if externalName == "" {
+			return "", nil
+		}
 		serviceName, err := serviceName(parameters)
 		if err != nil {
 			return serviceName, err


### PR DESCRIPTION
# Fix: Handle empty external-name in GetIDFn to prevent incomplete composite IDs

## Description

This PR fixes an issue where resources with composite ID formats were generating incomplete IDs in Terraform state when the `external-name` was empty (during initial resource creation). This caused Terraform refresh operations to fail with OVH API errors.

## Problem

When resources are being created, they don't yet have an `external-name` annotation set. However, the `GetIDFn` function was still being called during state initialization, causing it to construct **incomplete composite IDs** such as:

- `f93f1228ddd841578fc3069b5cf2fd7d/` (missing user_id for User resource)
- `f93f1228ddd841578fc3069b5cf2fd7d/EU-WEST-PAR/` (missing gateway_id for Gateway resource)
- `f93f1228ddd841578fc3069b5cf2fd7d/network-id/` (missing subnet_id for Subnet resource)

These incomplete IDs were then set in the Terraform state, causing subsequent refresh operations to fail with OVH API errors:

```
Error: Given data (f93f1228ddd841578fc3069b5cf2fd7d/EU-WEST-PAR/) is not valid for type uuid
Error: expected 'userId' to be of type int
```

### Root Cause

The issue occurs in the following flow:

1. Resource creation starts with empty `external-name`
2. `EnsureTFState()` is called to initialize Terraform state
3. `GetIDFn()` is called with empty `externalName` parameter
4. `GetIDFn()` constructs partial composite ID (e.g., `service_name/`)
5. Incomplete ID is set in tfstate
6. Terraform refresh tries to query OVH API with malformed ID
7. OVH API rejects the request

## Solution

Updated `GetIDFn` implementations for resources with composite ID formats to check if `externalName` is empty and return an empty string instead of constructing an incomplete ID.

### Changes

Modified `config/external_name.go` to add empty `externalName` checks in `GetIDFn` for:

1. **PrivateNetwork** (`ovh_cloud_project_network_private`)
   - Format: `service_name/network_id`
   - Check: Return `""` if `externalName` is empty

2. **Subnet** (`ovh_cloud_project_network_private_subnet`)
   - Format: `service_name/network_id/subnet_id`
   - Check: Return `""` if `externalName` is empty

3. **User** (`ovh_cloud_project_user`)
   - Format: `service_name/user_id`
   - Check: Return `""` if `externalName` is empty

4. **S3Credentials** (`ovh_cloud_project_user_s3_credential`)
   - Format: `service_name/user_id/access_key_id`
   - Check: Return `""` if `externalName` is empty

5. **Gateway** (`ovh_cloud_project_gateway`)
   - Format: `service_name/region/gateway_id`
   - Check: Return `""` if `externalName` is empty

6. **S3Policy** (`ovh_cloud_project_user_s3_policy`)
   - Format: `service_name/user_id`
   - Special case: Doesn't use `externalName` in ID, only added documentation comment

### Test Scenarios

| Scenario | Result |
|----------|--------|
| Create new PrivateNetwork | ✅ No refresh errors |
| Create new User | ✅ No refresh errors |
| Create new Gateway | ✅ No refresh errors |
| Create new S3Credentials | ✅ No refresh errors |
| Create new Subnet | ✅ No refresh errors |
| Import existing resources | ✅ Proper composite IDs used |
| Pod restart (async resources) | ✅ Import works correctly |

## Impact

- **Severity**: Bug fix for resource creation
- **Scope**: Affects 5 resources with composite ID formats
- **Risk**: Low - only changes behavior when `externalName` is empty
- **Breaking Changes**: None
- **Performance**: No impact

## Related Work

- Related to PR #38 which added proper external name configuration for `ovh_cloud_project_storage`
- Complements the upjet Import fallback fix for async resources after pod restart
- Part of ongoing work to improve external name configuration handling across all OVH resources

## Notes

This fix is essential for resources that use composite IDs (IDs composed of multiple parameters). When combined with the upjet Import fallback for async resources, it provides a complete solution for handling resource state across pod restarts and Velero backup/restore operations.

The S3Policy resource configuration was updated with documentation comments but doesn't require the empty check since its ID format (`service_name/user_id`) doesn't depend on the `externalName` value.