### PR TITLE
feat: provider: add a specific User-Agent inside configuration of the terraform provider

### DIFF
--- a/internal/clients/ovh.go
+++ b/internal/clients/ovh.go
@@ -79,7 +79,8 @@ func configureClient(ctx context.Context, pcSpec *namespacedv1beta1.ProviderConf
 
 	// Set credentials in Terraform provider configuration.
 	cfg := map[string]any{
-		"endpoint": creds.Endpoint,
+		"endpoint":         creds.Endpoint,
+		"user_agent_extra": "Crossplane/edixos/provider-ovh",
 	}
 
 	if creds.ApplicationKey != "" && creds.ApplicationSecret != "" && creds.ConsumerKey != "" {


### PR DESCRIPTION
### Description of your changes

Inject a fixed user-agent config inside the terraform provider config.
Goal is to be able to determine usage between people using terraform-provider-ovh directly or using it through Crossplane provider on OVHcloud side, to determine if the provider have a lot of usage or not.

### How has this code been tested

I used "make local-deploy" and checked that the configuration was correctly applied inside the terraform-provider config.