### PR TITLE
ovh: Add access_token cache

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,9 @@ require (
 	github.com/crossplane/crossplane-runtime/v2 v2.1.0
 	github.com/crossplane/crossplane-tools v0.0.0-20251017183449-dd4517244339
 	github.com/crossplane/upjet/v2 v2.2.0
+	github.com/ovh/go-ovh v1.9.0
 	github.com/pkg/errors v0.9.1
+	golang.org/x/oauth2 v0.32.0
 	google.golang.org/grpc v1.78.0
 	k8s.io/api v0.35.0
 	k8s.io/apiextensions-apiserver v0.34.0
@@ -108,7 +110,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.31.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
-	golang.org/x/oauth2 v0.32.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/term v0.38.0 // indirect
@@ -121,6 +122,7 @@ require (
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/code-generator v0.35.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -142,6 +142,8 @@ github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHL
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jarcoal/httpmock v1.3.0 h1:2RJ8GP0IIaWwcC9Fp2BmVi8Kog3v2Hn7VXM3fTd+nuc=
+github.com/jarcoal/httpmock v1.3.0/go.mod h1:3yb8rc4BI7TCBhFY8ng0gjuLKJNquuDNiPaZjnENuYg=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/jhump/protoreflect v1.15.1/go.mod h1:jD/2GMKKE6OqX8qTjhADU1e6DShO+gavG9e0Q693nKo=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -174,6 +176,8 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/maxatome/go-testdeep v1.12.0 h1:Ql7Go8Tg0C1D/uMMX59LAoYK7LffeJQ6X2T04nTH68g=
+github.com/maxatome/go-testdeep v1.12.0/go.mod h1:lPZc/HAcJMP92l7yI6TRz1aZN5URwUBUAfUNvrclaNM=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-ps v1.0.0 h1:i6ampVEEF4wQFF+bkYfwYgY+F/uYJDktmvLPf7qIgjc=
@@ -207,6 +211,8 @@ github.com/onsi/ginkgo/v2 v2.27.2 h1:LzwLj0b89qtIy6SSASkzlNvX6WktqurSHwkk2ipF/Ns
 github.com/onsi/ginkgo/v2 v2.27.2/go.mod h1:ArE1D/XhNXBXCBkKOLkbsb2c81dQHCRcF5zwn/ykDRo=
 github.com/onsi/gomega v1.38.2 h1:eZCjf2xjZAqe+LeWvKb5weQ+NcPwX84kqJ0cZNxok2A=
 github.com/onsi/gomega v1.38.2/go.mod h1:W2MJcYxRGV63b418Ai34Ud0hEdTVXq9NW9+Sx6uXf3k=
+github.com/ovh/go-ovh v1.9.0 h1:6K8VoL3BYjVV3In9tPJUdT7qMx9h0GExN9EXx1r2kKE=
+github.com/ovh/go-ovh v1.9.0/go.mod h1:cTVDnl94z4tl8pP1uZ/8jlVxntjSIf09bNcQ5TJSC7c=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -409,6 +415,8 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnf
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
+gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/internal/clients/oauth_token_cache.go
+++ b/internal/clients/oauth_token_cache.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2021 Upbound Inc.
+*/
+
+package clients
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ovh/go-ovh/ovh"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+const (
+	// Cache TTL for OAuth access tokens (50 minutes, tokens valid for 1 hour)
+	tokenCacheTTL = 50 * time.Minute
+)
+
+// tokenCache holds cached OAuth access tokens to avoid repeated authentication
+type tokenCache struct {
+	mu    sync.RWMutex
+	cache map[string]*cachedToken
+}
+
+// cachedToken represents a cached access token with expiration
+type cachedToken struct {
+	accessToken string
+	expiresAt   time.Time
+}
+
+// Global token cache to reuse OAuth access tokens across reconciliations
+var globalTokenCache = &tokenCache{
+	cache: make(map[string]*cachedToken),
+}
+
+// get retrieves a cached token if it exists and is not expired
+func (c *tokenCache) get(key string) (string, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	cached, exists := c.cache[key]
+	if !exists {
+		return "", false
+	}
+
+	// Check if expired (with 5-minute buffer)
+	if time.Now().Add(5 * time.Minute).After(cached.expiresAt) {
+		return "", false
+	}
+
+	return cached.accessToken, true
+}
+
+// set stores a token in the cache with TTL
+func (c *tokenCache) set(key, token string, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.cache[key] = &cachedToken{
+		accessToken: token,
+		expiresAt:   time.Now().Add(ttl),
+	}
+}
+
+// cleanup removes expired entries from the cache
+func (c *tokenCache) cleanup() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := time.Now()
+	for key, cached := range c.cache {
+		if now.After(cached.expiresAt) {
+			delete(c.cache, key)
+		}
+	}
+}
+
+// oauthTokenURLs maps OVH API endpoint URLs to their OAuth token endpoints.
+// Mirrors the unexported tokensURLs from github.com/ovh/go-ovh/ovh.
+var oauthTokenURLs = map[string]string{
+	ovh.OvhEU: "https://www.ovh.com/auth/oauth2/token",
+	ovh.OvhCA: "https://ca.ovh.com/auth/oauth2/token",
+	ovh.OvhUS: "https://us.ovhcloud.com/auth/oauth2/token",
+}
+
+// resolveEndpoint converts an endpoint name (e.g. "ovh-eu") to the full URL,
+// or returns it as-is if it already looks like a URL.
+func resolveEndpoint(endpoint string) string {
+	if strings.Contains(endpoint, "/") {
+		return endpoint
+	}
+	if url, ok := ovh.Endpoints[endpoint]; ok {
+		return url
+	}
+	return endpoint
+}
+
+// resolveTokenURL returns the OAuth token URL for the given API endpoint.
+func resolveTokenURL(endpoint string) (string, error) {
+	apiURL := resolveEndpoint(endpoint)
+	if tokenURL, ok := oauthTokenURLs[apiURL]; ok {
+		return tokenURL, nil
+	}
+	return "", fmt.Errorf("no OAuth token URL known for endpoint %q", endpoint)
+}
+
+// getOrExchangeToken retrieves a cached token or performs OAuth exchange
+// using golang.org/x/oauth2/clientcredentials (the same library the go-ovh SDK uses).
+func getOrExchangeToken(ctx context.Context, cacheKey, clientID, clientSecret, endpoint string) (string, error) {
+	// Try to get from cache first
+	if token, found := globalTokenCache.get(cacheKey); found {
+		return token, nil
+	}
+
+	// Resolve the OAuth token endpoint URL
+	tokenURL, err := resolveTokenURL(endpoint)
+	if err != nil {
+		return "", err
+	}
+
+	// Use the same clientcredentials flow as the go-ovh SDK
+	conf := &clientcredentials.Config{
+		ClientID:     clientID,
+		ClientSecret: clientSecret,
+		TokenURL:     tokenURL,
+		Scopes:       []string{"all"},
+	}
+
+	// This actually performs the HTTP POST to get the access token
+	token, err := conf.TokenSource(ctx).Token()
+	if err != nil {
+		return "", fmt.Errorf("OAuth token exchange failed: %w", err)
+	}
+
+	if token.AccessToken == "" {
+		return "", fmt.Errorf("OAuth exchange succeeded but access token is empty")
+	}
+
+	// Cache the token; use the server-reported expiry if available
+	ttl := tokenCacheTTL
+	if !token.Expiry.IsZero() {
+		serverTTL := time.Until(token.Expiry) - 5*time.Minute // 5-min safety margin
+		if serverTTL > 0 && serverTTL < ttl {
+			ttl = serverTTL
+		}
+	}
+	globalTokenCache.set(cacheKey, token.AccessToken, ttl)
+
+	return token.AccessToken, nil
+}
+
+func init() {
+	// Start a background goroutine to periodically clean up expired cache entries
+	go func() {
+		ticker := time.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			globalTokenCache.cleanup()
+		}
+	}()
+}

--- a/internal/clients/ovh.go
+++ b/internal/clients/ovh.go
@@ -7,13 +7,13 @@ package clients
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+	"github.com/crossplane/upjet/v2/pkg/terraform"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/crossplane/upjet/v2/pkg/terraform"
 
 	clusterv1beta1 "github.com/edixos/provider-ovh/apis/cluster/v1beta1"
 	namespacedv1beta1 "github.com/edixos/provider-ovh/apis/namespaced/v1beta1"
@@ -38,6 +38,17 @@ type OVHCredentials struct {
 	ClientSecret      string `json:"client_secret,omitempty"`
 }
 
+// buildCacheKey constructs a cache key from ProviderConfig name and secret reference
+func buildCacheKey(providerConfigName string, pcSpec *namespacedv1beta1.ProviderConfigSpec) string {
+	var secretNamespace, secretName string
+	if pcSpec.Credentials.SecretRef != nil {
+		secretNamespace = pcSpec.Credentials.SecretRef.Namespace
+		secretName = pcSpec.Credentials.SecretRef.Name
+	}
+	// Format: providerconfig:namespace/secret
+	return fmt.Sprintf("%s:%s/%s", providerConfigName, secretNamespace, secretName)
+}
+
 // TerraformSetupBuilder builds Terraform a terraform.SetupFn function which
 // returns Terraform provider setup configuration
 func TerraformSetupBuilder(version, providerSource, providerVersion string) terraform.SetupFn {
@@ -55,7 +66,20 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 			return terraform.Setup{}, errors.Wrap(err, "cannot resolve provider config")
 		}
 
-		cfg, err := configureClient(ctx, pcSpec, client)
+		// Build cache key from ProviderConfig reference and secret reference
+		var cacheKey string
+		switch managed := mg.(type) {
+		case resource.LegacyManaged:
+			if ref := managed.GetProviderConfigReference(); ref != nil {
+				cacheKey = buildCacheKey(ref.Name, pcSpec)
+			}
+		case resource.ModernManaged:
+			if ref := managed.GetProviderConfigReference(); ref != nil {
+				cacheKey = buildCacheKey(ref.Name, pcSpec)
+			}
+		}
+
+		cfg, err := configureClient(ctx, pcSpec, cacheKey, client)
 		if err != nil {
 			return ps, err
 		}
@@ -66,7 +90,7 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 	}
 }
 
-func configureClient(ctx context.Context, pcSpec *namespacedv1beta1.ProviderConfigSpec, client client.Client) (map[string]any, error) {
+func configureClient(ctx context.Context, pcSpec *namespacedv1beta1.ProviderConfigSpec, cacheKey string, client client.Client) (map[string]any, error) {
 	data, err := resource.CommonCredentialExtractor(ctx, pcSpec.Credentials.Source, client, pcSpec.Credentials.CommonCredentialSelectors)
 	if err != nil {
 		return nil, errors.Wrap(err, errExtractCredentials)
@@ -77,13 +101,15 @@ func configureClient(ctx context.Context, pcSpec *namespacedv1beta1.ProviderConf
 		return nil, errors.Wrap(err, errUnmarshalCredentials)
 	}
 
-	// Set credentials in Terraform provider configuration.
+	// Base configuration
 	cfg := map[string]any{
 		"endpoint":         creds.Endpoint,
 		"user_agent_extra": "Crossplane/edixos/provider-ovh",
 	}
 
+	// Configure based on credential type
 	if creds.ApplicationKey != "" && creds.ApplicationSecret != "" && creds.ConsumerKey != "" {
+		// Application key authentication (legacy method)
 		cfg["application_key"] = creds.ApplicationKey
 		cfg["application_secret"] = creds.ApplicationSecret
 		cfg["consumer_key"] = creds.ConsumerKey
@@ -91,8 +117,18 @@ func configureClient(ctx context.Context, pcSpec *namespacedv1beta1.ProviderConf
 	}
 
 	if creds.ClientID != "" && creds.ClientSecret != "" {
-		cfg["client_id"] = creds.ClientID
-		cfg["client_secret"] = creds.ClientSecret
+		// OAuth/OIDC authentication with token caching
+		// Exchange credentials for access token (uses cache to avoid repeated exchanges)
+		// cacheKey is based on ProviderConfig name + secret reference, not credential values
+		accessToken, err := getOrExchangeToken(ctx, cacheKey, creds.ClientID, creds.ClientSecret, creds.Endpoint)
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot obtain OAuth access token")
+		}
+
+		// Use the access_token parameter instead of client_id/client_secret
+		// This way the Terraform provider doesn't perform OAuth exchange itself
+		cfg["access_token"] = accessToken
+
 		return cfg, nil
 	}
 


### PR DESCRIPTION
### Description of your changes

This adds support for caching of token using the go-ovh sdk to get the token then caching it across the provider instance.

Fixes #48 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
