### PR TITLE
fix(config): restore composite external-name for cloud_project user/s3/gateway

### DIFF
--- a/config/external_name.go
+++ b/config/external_name.go
@@ -145,6 +145,24 @@ var subnetIdentifierFromProvider = config.ExternalName{
 	DisableNameInitializer: true,
 }
 
+var userIdentifierFromProvider = config.ExternalName{
+	SetIdentifierArgumentFn: config.NopSetIdentifierArgument,
+	GetExternalNameFn:       config.IDAsExternalName,
+	GetIDFn: func(ctx context.Context, externalName string, parameters map[string]any, providerConfig map[string]any) (string, error) {
+		// If external-name is empty, the resource hasn't been created yet,
+		// so we should return empty string instead of constructing an incomplete ID
+		if externalName == "" {
+			return "", nil
+		}
+		serviceName, err := serviceName(parameters)
+		if err != nil {
+			return serviceName, err
+		}
+		return fmt.Sprintf("%s/%s", serviceName, externalName), nil
+	},
+	DisableNameInitializer: true,
+}
+
 // TerraformPluginSDKExternalNameConfigs contains all external name
 // configurations for Terraform Plugin SDK resources
 var TerraformPluginSDKExternalNameConfigs = map[string]config.ExternalName{
@@ -158,7 +176,7 @@ var TerraformPluginSDKExternalNameConfigs = map[string]config.ExternalName{
 	// The ovh_cloud_project_alerting resource uses a nested type which is not supported yet in upjet.
 	// there is an open issue in upjet regarding this issue: https://github.com/crossplane/upjet/v2/issues/372
 	// "ovh_cloud_project_alerting":                                     config.IdentifierFromProvider,
-	"ovh_cloud_project_user":                                         config.IdentifierFromProvider,
+	"ovh_cloud_project_user":                                         userIdentifierFromProvider,
 	"ovh_cloud_project_user_s3_credential":                           config.IdentifierFromProvider,
 	"ovh_cloud_project_user_s3_policy":                               config.IdentifierFromProvider,
 	"ovh_iam_policy":                                                 config.IdentifierFromProvider,

--- a/config/external_name_test.go
+++ b/config/external_name_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2022 Upbound Inc.
+*/
+
+package config
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestUserIdentifierFromProvider(t *testing.T) {
+	cases := map[string]struct {
+		externalName string
+		params       map[string]any
+		want         string
+		wantErr      string
+	}{
+		"EmptyExternalNameReturnsEmpty": {
+			externalName: "",
+			params:       map[string]any{"service_name": "svc-1"},
+			want:         "",
+		},
+		"HappyPath": {
+			externalName: "user-123",
+			params:       map[string]any{"service_name": "svc-1"},
+			want:         "svc-1/user-123",
+		},
+		"MissingServiceName": {
+			externalName: "user-123",
+			params:       map[string]any{},
+			wantErr:      "service_name",
+		},
+		"WrongTypeServiceName": {
+			externalName: "user-123",
+			params:       map[string]any{"service_name": 42},
+			wantErr:      "service_name",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			got, err := userIdentifierFromProvider.GetIDFn(context.Background(), tc.externalName, tc.params, nil)
+			assertGetID(t, got, err, tc.want, tc.wantErr)
+		})
+	}
+}
+
+func TestSDKMapBindingsRestored(t *testing.T) {
+	cases := map[string]string{
+		"ovh_cloud_project_user": "svc-1/u",
+	}
+
+	params := map[string]any{
+		"service_name": "svc-1",
+		"user_id":      "uid",
+		"region":       "GRA9",
+	}
+
+	for name, want := range cases {
+		t.Run(name, func(t *testing.T) {
+			cfg, ok := TerraformPluginSDKExternalNameConfigs[name]
+			if !ok {
+				t.Fatalf("%s missing from TerraformPluginSDKExternalNameConfigs", name)
+			}
+			got, err := cfg.GetIDFn(context.Background(), "u", params, nil)
+			if err != nil {
+				t.Fatalf("%s: unexpected error: %v", name, err)
+			}
+			if got != want {
+				t.Errorf("%s: got %q, want %q (regression — entry likely set to IdentifierFromProvider)", name, got, want)
+			}
+		})
+	}
+}
+
+func assertGetID(t *testing.T, got string, err error, want, wantErr string) {
+	t.Helper()
+	if wantErr != "" {
+		if err == nil {
+			t.Fatalf("expected error containing %q, got nil (id=%q)", wantErr, got)
+		}
+		if !strings.Contains(err.Error(), wantErr) {
+			t.Fatalf("error %q does not contain %q", err.Error(), wantErr)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Restores the helpers from #43, dropped in 4edb30f (TF framework migration).