### PR TITLE
feat(postgresql): recover orphaned users after OVH create failures

### DIFF
--- a/config/external_name.go
+++ b/config/external_name.go
@@ -7,11 +7,13 @@ package config
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/crossplane/crossplane-runtime/v2/pkg/errors"
 	"github.com/crossplane/upjet/v2/pkg/config"
 	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	goovh "github.com/ovh/go-ovh/ovh"
 )
 
 const (
@@ -60,6 +62,104 @@ func serviceName(parameters map[string]any) (string, error) {
 		return "", errors.Errorf(ErrFmtUnexpectedType, "service_name")
 	}
 	return serviceNameStr, nil
+}
+
+func clusterID(parameters map[string]any) (string, error) {
+	clusterID, ok := parameters["cluster_id"]
+	if !ok {
+		return "", errors.Errorf(ErrFmtNoAttribute, "cluster_id")
+	}
+	clusterIDStr, ok := clusterID.(string)
+	if !ok {
+		return "", errors.Errorf(ErrFmtUnexpectedType, "cluster_id")
+	}
+	return clusterIDStr, nil
+}
+
+func databaseUserName(parameters map[string]any) (string, error) {
+	userName, ok := parameters["name"]
+	if !ok {
+		return "", errors.Errorf(ErrFmtNoAttribute, "name")
+	}
+	userNameStr, ok := userName.(string)
+	if !ok {
+		return "", errors.Errorf(ErrFmtUnexpectedType, "name")
+	}
+	return userNameStr, nil
+}
+
+func providerConfigString(providerConfig map[string]any, key string) (string, error) {
+	value, ok := providerConfig[key]
+	if !ok {
+		return "", errors.Errorf(ErrFmtNoAttribute, key)
+	}
+	valueStr, ok := value.(string)
+	if !ok {
+		return "", errors.Errorf(ErrFmtUnexpectedType, key)
+	}
+	return valueStr, nil
+}
+
+func newOVHClient(providerConfig map[string]any) (*goovh.Client, error) {
+	endpoint, err := providerConfigString(providerConfig, "endpoint")
+	if err != nil {
+		return nil, err
+	}
+
+	if accessToken, ok := providerConfig["access_token"].(string); ok && accessToken != "" {
+		return goovh.NewAccessTokenClient(endpoint, accessToken)
+	}
+
+	applicationKey, err := providerConfigString(providerConfig, "application_key")
+	if err != nil {
+		return nil, err
+	}
+	applicationSecret, err := providerConfigString(providerConfig, "application_secret")
+	if err != nil {
+		return nil, err
+	}
+	consumerKey, err := providerConfigString(providerConfig, "consumer_key")
+	if err != nil {
+		return nil, err
+	}
+
+	return goovh.NewClient(endpoint, applicationKey, applicationSecret, consumerKey)
+}
+
+func lookupPostgresqlUserID(ctx context.Context, providerConfig map[string]any, serviceName, clusterID, userName string) (string, error) {
+	client, err := newOVHClient(providerConfig)
+	if err != nil {
+		return "", err
+	}
+
+	listEndpoint := fmt.Sprintf("/cloud/project/%s/database/postgresql/%s/user",
+		url.PathEscape(serviceName),
+		url.PathEscape(clusterID),
+	)
+	ids := make([]string, 0)
+	if err := client.GetWithContext(ctx, listEndpoint, &ids); err != nil {
+		return "", err
+	}
+
+	for _, id := range ids {
+		endpoint := fmt.Sprintf("/cloud/project/%s/database/postgresql/%s/user/%s",
+			url.PathEscape(serviceName),
+			url.PathEscape(clusterID),
+			url.PathEscape(id),
+		)
+		response := struct {
+			ID       string `json:"id"`
+			Username string `json:"username"`
+		}{}
+		if err := client.GetWithContext(ctx, endpoint, &response); err != nil {
+			return "", err
+		}
+		if response.Username == userName {
+			return response.ID, nil
+		}
+	}
+
+	return "", nil
 }
 
 var kubePoolIdentifierFromProvider = config.ExternalName{
@@ -163,6 +263,47 @@ var userIdentifierFromProvider = config.ExternalName{
 	DisableNameInitializer: true,
 }
 
+var postgresqlUserIdentifierFromProvider = config.ExternalName{
+	SetIdentifierArgumentFn: config.NopSetIdentifierArgument,
+	GetExternalNameFn:       config.IDAsExternalName,
+	GetIDFn: func(ctx context.Context, externalName string, parameters map[string]any, providerConfig map[string]any) (string, error) {
+		if externalName != "" {
+			serviceName, err := serviceName(parameters)
+			if err != nil {
+				return serviceName, err
+			}
+			clusterID, err := clusterID(parameters)
+			if err != nil {
+				return "", err
+			}
+			return fmt.Sprintf("%s/%s/%s", serviceName, clusterID, externalName), nil
+		}
+
+		serviceName, err := serviceName(parameters)
+		if err != nil {
+			return "", nil
+		}
+		clusterID, err := clusterID(parameters)
+		if err != nil {
+			return "", nil
+		}
+		userName, err := databaseUserName(parameters)
+		if err != nil {
+			return "", nil
+		}
+
+		// Best-effort orphan recovery: if create failed after the OVH API created
+		// the user, resolve the provider ID by name and import on the next reconcile.
+		resolvedID, err := lookupPostgresqlUserID(ctx, providerConfig, serviceName, clusterID, userName)
+		if err != nil || resolvedID == "" {
+			return "", nil
+		}
+
+		return fmt.Sprintf("%s/%s/%s", serviceName, clusterID, resolvedID), nil
+	},
+	DisableNameInitializer: true,
+}
+
 // TerraformPluginSDKExternalNameConfigs contains all external name
 // configurations for Terraform Plugin SDK resources
 var TerraformPluginSDKExternalNameConfigs = map[string]config.ExternalName{
@@ -234,7 +375,7 @@ var TerraformPluginSDKExternalNameConfigs = map[string]config.ExternalName{
 	"ovh_cloud_project_database_mongodb_user":                        config.IdentifierFromProvider,
 	"ovh_cloud_project_database_opensearch_pattern":                  config.IdentifierFromProvider,
 	"ovh_cloud_project_database_opensearch_user":                     config.IdentifierFromProvider,
-	"ovh_cloud_project_database_postgresql_user":                     config.IdentifierFromProvider,
+	"ovh_cloud_project_database_postgresql_user":                     postgresqlUserIdentifierFromProvider,
 	"ovh_cloud_project_database_postgresql_connection_pool":          config.IdentifierFromProvider,
 	"ovh_cloud_project_database_redis_user":                          config.IdentifierFromProvider,
 	"ovh_cloud_project_database_user":                                config.IdentifierFromProvider,

--- a/config/external_name_test.go
+++ b/config/external_name_test.go
@@ -6,6 +6,9 @@ package config
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -49,11 +52,13 @@ func TestUserIdentifierFromProvider(t *testing.T) {
 
 func TestSDKMapBindingsRestored(t *testing.T) {
 	cases := map[string]string{
-		"ovh_cloud_project_user": "svc-1/u",
+		"ovh_cloud_project_user":                     "svc-1/u",
+		"ovh_cloud_project_database_postgresql_user": "svc-1/cluster-1/u",
 	}
 
 	params := map[string]any{
 		"service_name": "svc-1",
+		"cluster_id":   "cluster-1",
 		"user_id":      "uid",
 		"region":       "GRA9",
 	}
@@ -73,6 +78,103 @@ func TestSDKMapBindingsRestored(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPostgresqlUserIdentifierFromProvider(t *testing.T) {
+	t.Run("UsesExternalNameWhenPresent", func(t *testing.T) {
+		got, err := postgresqlUserIdentifierFromProvider.GetIDFn(context.Background(), "user-123", map[string]any{
+			"service_name": "svc-1",
+			"cluster_id":   "cluster-1",
+		}, nil)
+		assertGetID(t, got, err, "svc-1/cluster-1/user-123", "")
+	})
+
+	t.Run("ResolvesMissingExternalNameFromOVH", func(t *testing.T) {
+		server := newPostgresqlUserLookupServer(t, map[string]string{
+			"user-111": "someone-else",
+			"user-123": "johndoe",
+		})
+		defer server.Close()
+
+		got, err := postgresqlUserIdentifierFromProvider.GetIDFn(context.Background(), "", map[string]any{
+			"service_name": "svc-1",
+			"cluster_id":   "cluster-1",
+			"name":         "johndoe",
+		}, map[string]any{
+			"endpoint":     server.URL,
+			"access_token": "token",
+		})
+		assertGetID(t, got, err, "svc-1/cluster-1/user-123", "")
+	})
+
+	t.Run("LookupMissReturnsEmpty", func(t *testing.T) {
+		server := newPostgresqlUserLookupServer(t, map[string]string{
+			"user-111": "someone-else",
+		})
+		defer server.Close()
+
+		got, err := postgresqlUserIdentifierFromProvider.GetIDFn(context.Background(), "", map[string]any{
+			"service_name": "svc-1",
+			"cluster_id":   "cluster-1",
+			"name":         "johndoe",
+		}, map[string]any{
+			"endpoint":     server.URL,
+			"access_token": "token",
+		})
+		assertGetID(t, got, err, "", "")
+	})
+
+	t.Run("MissingClusterIDWithoutExternalNameReturnsEmpty", func(t *testing.T) {
+		got, err := postgresqlUserIdentifierFromProvider.GetIDFn(context.Background(), "", map[string]any{
+			"service_name": "svc-1",
+			"name":         "johndoe",
+		}, nil)
+		assertGetID(t, got, err, "", "")
+	})
+
+	t.Run("MissingClusterID", func(t *testing.T) {
+		got, err := postgresqlUserIdentifierFromProvider.GetIDFn(context.Background(), "user-123", map[string]any{
+			"service_name": "svc-1",
+		}, nil)
+		assertGetID(t, got, err, "", "cluster_id")
+	})
+}
+
+func newPostgresqlUserLookupServer(t *testing.T, users map[string]string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		path := strings.TrimPrefix(r.URL.Path, "/1.0")
+		switch path {
+		case "/cloud/project/svc-1/database/postgresql/cluster-1/user":
+			ids := make([]string, 0, len(users))
+			for id := range users {
+				ids = append(ids, id)
+			}
+			if err := json.NewEncoder(w).Encode(ids); err != nil {
+				t.Fatalf("encode ids: %v", err)
+			}
+			return
+		}
+
+		prefix := "/cloud/project/svc-1/database/postgresql/cluster-1/user/"
+		if strings.HasPrefix(path, prefix) {
+			id := strings.TrimPrefix(path, prefix)
+			username, ok := users[id]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			if err := json.NewEncoder(w).Encode(map[string]string{"id": id, "username": username}); err != nil {
+				t.Fatalf("encode user: %v", err)
+			}
+			return
+		}
+
+		w.WriteHeader(http.StatusNotFound)
+	}))
 }
 
 func assertGetID(t *testing.T, got string, err error, want, wantErr string) {

--- a/config/external_name_test.go
+++ b/config/external_name_test.go
@@ -147,8 +147,7 @@ func newPostgresqlUserLookupServer(t *testing.T, users map[string]string) *httpt
 		w.Header().Set("Content-Type", "application/json")
 
 		path := strings.TrimPrefix(r.URL.Path, "/1.0")
-		switch path {
-		case "/cloud/project/svc-1/database/postgresql/cluster-1/user":
+		if path == "/cloud/project/svc-1/database/postgresql/cluster-1/user" {
 			ids := make([]string, 0, len(users))
 			for id := range users {
 				ids = append(ids, id)


### PR DESCRIPTION
## Summary
- add a custom external-name resolver for `ovh_cloud_project_database_postgresql_user`
- resolve the OVH user ID by `service_name`, `cluster_id`, and username when create returned an error but the user may already exist
- let the next reconcile adopt the orphaned user instead of looping forever on `409 already exists`
- add focused tests for direct IDs, lookup-based recovery, misses, and non-fatal unresolved parameters

## Workaround
This is a provider-side workaround for the case described in #53 where OVH returns `500` during PostgreSQL user creation but still creates the user.

When Crossplane does not have an external name yet, the provider now performs a best-effort OVH lookup by username and builds the Terraform import ID `service_name/cluster_id/id`.
That allows Upjet to import the already-created user on the next reconcile instead of retrying create and getting stuck on `409`.

The underlying create bug still appears to be upstream in the OVH Terraform/API flow.

## Testing
- `go test ./config -run 'Test(UserIdentifierFromProvider|SDKMapBindingsRestored|PostgresqlUserIdentifierFromProvider)$'`

Refs #53
Related: ovh/terraform-provider-ovh#1306