### PR TITLE
fix(test): update Postgresql user identifier tests to handle nested c…

### DIFF
--- a/config/external_name.go
+++ b/config/external_name.go
@@ -101,6 +101,12 @@ func providerConfigString(providerConfig map[string]any, key string) (string, er
 }
 
 func newOVHClient(providerConfig map[string]any) (*goovh.Client, error) {
+	// providerConfig comes from terraform.Setup.Map(), which nests
+	// the actual provider credentials under the "configuration" key.
+	if cfg, ok := providerConfig["configuration"].(map[string]any); ok {
+		providerConfig = cfg
+	}
+
 	endpoint, err := providerConfigString(providerConfig, "endpoint")
 	if err != nil {
 		return nil, err

--- a/config/external_name_test.go
+++ b/config/external_name_test.go
@@ -96,6 +96,28 @@ func TestPostgresqlUserIdentifierFromProvider(t *testing.T) {
 		})
 		defer server.Close()
 
+		// Use nested "configuration" structure matching production ts.Map() format
+		got, err := postgresqlUserIdentifierFromProvider.GetIDFn(context.Background(), "", map[string]any{
+			"service_name": "svc-1",
+			"cluster_id":   "cluster-1",
+			"name":         "johndoe",
+		}, map[string]any{
+			"configuration": map[string]any{
+				"endpoint":     server.URL,
+				"access_token": "token",
+			},
+		})
+		assertGetID(t, got, err, "svc-1/cluster-1/user-123", "")
+	})
+
+	t.Run("ResolvesMissingExternalNameFromOVH_FlatProviderConfig", func(t *testing.T) {
+		// Also works when providerConfig is flat (e.g. direct unit-test use)
+		server := newPostgresqlUserLookupServer(t, map[string]string{
+			"user-111": "someone-else",
+			"user-123": "johndoe",
+		})
+		defer server.Close()
+
 		got, err := postgresqlUserIdentifierFromProvider.GetIDFn(context.Background(), "", map[string]any{
 			"service_name": "svc-1",
 			"cluster_id":   "cluster-1",
@@ -118,8 +140,10 @@ func TestPostgresqlUserIdentifierFromProvider(t *testing.T) {
 			"cluster_id":   "cluster-1",
 			"name":         "johndoe",
 		}, map[string]any{
-			"endpoint":     server.URL,
-			"access_token": "token",
+			"configuration": map[string]any{
+				"endpoint":     server.URL,
+				"access_token": "token",
+			},
 		})
 		assertGetID(t, got, err, "", "")
 	})


### PR DESCRIPTION
…onfiguration structure

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes
The bug: GetIDFn receives providerConfig from terraform.Setup.Map(), which nests the actual credentials under a "configuration" key:

Our newOVHClient() was looking for "endpoint" at the top level, which always failed. The error was silently swallowed by return "", nil in the recovery path, so the resource was reported as "not found" → Create was retried → 409.

The fix ([external_name.go:106-110](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)): newOVHClient now extracts the nested "configuration" map before accessing credentials. It also still works with a flat map for backward compatibility.
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #53 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
